### PR TITLE
Added support for Bytes16 type

### DIFF
--- a/solsha3.go
+++ b/solsha3.go
@@ -446,6 +446,22 @@ func Bytes32(input interface{}) []byte {
 	}
 }
 
+// Bytes16 bytes16
+func Bytes16(input interface{}) []byte {
+	switch v := input.(type) {
+	case [16]byte:
+		return common.RightPadBytes(v[:], 16)
+	case []byte:
+		return common.RightPadBytes(v, 16)
+	case string:
+		str := fmt.Sprintf("%x", v)
+		hexb, _ := hex.DecodeString(str)
+		return common.RightPadBytes(hexb, 16)
+	default:
+		return common.RightPadBytes([]byte(""), 16)
+	}
+}
+
 // String string
 func String(input interface{}) []byte {
 	switch v := input.(type) {


### PR DESCRIPTION
Using the existing Bytes32 type to hash a bytes16 value does not yield the correct hash. This pull request fixes this by adding a new Bytes16 type.